### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -21,10 +21,12 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Capture metadata for prompt
+        env:
+          FAILED_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           echo "FAILED_WORKFLOW=${{ github.event.workflow_run.name }}" >> $GITHUB_ENV
           echo "FAILED_URL=${{ github.event.workflow_run.html_url }}" >> $GITHUB_ENV
-          echo "FAILED_BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
+          echo "FAILED_BRANCH=$FAILED_BRANCH" >> $GITHUB_ENV
           echo "FAILED_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
 
       # Optional: reproduce locally first (your CI uses pytest, ruff, mypy)


### PR DESCRIPTION
Potential fix for [https://github.com/bwedderburn/amp-benchkit/security/code-scanning/5](https://github.com/bwedderburn/amp-benchkit/security/code-scanning/5)

To fix the code injection vulnerability, assign the possibly unsafe input value (`${{ github.event.workflow_run.head_branch }}`) directly to an environment variable—without invoking shell expansion on it—in the step's `env` block. Then, reference this variable safely within the shell by using native shell variable expansion (e.g., `$FAILED_BRANCH`) rather than the `${{ }}` syntax. Specifically: for each line in the script that writes `echo "FAILED_BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV`, replace it by providing an `env` block to the step that defines `FAILED_BRANCH: ${{ github.event.workflow_run.head_branch }}` and, inside the shell script, use `echo "FAILED_BRANCH=$FAILED_BRANCH" >> $GITHUB_ENV`. This ensures the shell receives the raw value without opportunity for interpretation of metacharacters, as environment variables in shell are expanded directly and safely.

Required changes:

- Step at line 23 (`Capture metadata for prompt`): Add an `env` block providing `FAILED_BRANCH: ${{ github.event.workflow_run.head_branch }}`.
- In script under `run: |`, change `echo "FAILED_BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV` to `echo "FAILED_BRANCH=$FAILED_BRANCH" >> $GITHUB_ENV`.
- No change is needed for other assignments (as CodeQL only highlights head_branch); however, best practice is to apply the same pattern for all user-controlled values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
