### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-Commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bwedderburn/amp-benchkit/security/code-scanning/1](https://github.com/bwedderburn/amp-benchkit/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. This should be done at the root level, directly below the `name` or `on` keys, or at the job level (at the same level as `runs-on`). Since there is only one job and the workflow does not appear to need any write or administration permissions (it primarily checks out code, installs dependencies, caches, and runs pre-commit hooks), the strictest and recommended setting is `contents: read`. This will minimize the permissions of the `GITHUB_TOKEN` during the workflow run. Add the following block:

```yaml
permissions:
  contents: read
```

right after the `name: Pre-Commit` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
