### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bwedderburn/amp-benchkit/security/code-scanning/2](https://github.com/bwedderburn/amp-benchkit/security/code-scanning/2)

To fix this issue, add a `permissions` block at the root of the workflow file (`.github/workflows/ci.yml`) so that the least privilege is granted to the `GITHUB_TOKEN` when this workflow runs. Since none of the jobs need to write to repository contents or interact with pull requests/issues, the block should be set to `contents: read` (matching the recommended minimal setting). This change should be made at the top level of the YAML, directly after the workflow’s `name`, and before the `on` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
