### PR TITLE
ci: guard autofix job from untrusted PR runs

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   codex_autofix:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && (github.event.workflow_run.event != 'pull_request' || github.event.workflow_run.head_repository.full_name == github.repository) }}
     runs-on: ubuntu-latest
     env:
       FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}


### PR DESCRIPTION
## Summary
- tighten the codex autofix job condition so workflow_run PRs from forks skip entirely
- keeps the existing runtime trust gate as defense in depth but satisfies CodeQL

## Testing
- pre-commit run --all-files